### PR TITLE
Fix renamed methods (Realm 0.90.5)

### DIFF
--- a/MRRealmResultsController.podspec
+++ b/MRRealmResultsController.podspec
@@ -16,7 +16,7 @@ Pod::Spec.new do |s|
   s.source       = { :git => "https://github.com/hectr/MRRealmResultsController.git", :tag => s.version.to_s }
   s.source_files = "MRRealmResultsController"
   # s.library    = "libc++"
-  s.dependency   "Realm"
+  s.dependency   "Realm", "0.90.5"
   s.requires_arc = true
   s.platform     = :ios, '6.0'
 

--- a/MRRealmResultsController/MRRealmResultsController.m
+++ b/MRRealmResultsController/MRRealmResultsController.m
@@ -74,8 +74,8 @@
             [sourceObjects objectsWithPredicate:predicate];
             NSSortDescriptor *const sort = self.secondarySort;
             if (sort) {
-                _objects = [unsortedObjects arraySortedByProperty:sort.key
-                                                        ascending:sort.ascending];
+                _objects = [unsortedObjects sortedResultsUsingProperty:sort.key
+                                                             ascending:sort.ascending];
             } else {
                 _objects = unsortedObjects;
             }
@@ -157,8 +157,8 @@ sectionSortDescriptor:(NSSortDescriptor *const)sectionSortDescriptorOrNil
         }
         NSSortDescriptor *const primarySort = self.mr_primarySort;
         if (primarySort) {
-            _fetchedObjects = [array arraySortedByProperty:primarySort.key
-                                                 ascending:primarySort.ascending];
+            _fetchedObjects = [array sortedResultsUsingProperty:primarySort.key
+                                                      ascending:primarySort.ascending];
         } else {
             _fetchedObjects = array;
         }


### PR DESCRIPTION
Hi,

Fixed references to this `RLMArray` method that was renamed in https://github.com/realm/realm-cocoa/commit/3d82b12ac0a474710e5e543b38ba2110f8ee4b10.

Also, set the Realm dependency version in the podspec - development seems pretty active, including breaking changes.

Thanks!
